### PR TITLE
feat(MOBT-329): Adding Cocoapods path to run.

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,7 @@ Create a workflow in your project's `bitrise.yml` as shown next
     - git::https://github.com/Zegocover/bitrise-snyk-scan.git: 
         title: Snyk
         inputs:
+        - project_directory: $BITRISE_SOURCE_DIR // project directory is different from the source dir?
         - os_list: ios // is the project ios or android?
         - severity_threshold: low // critical is not supported by'snyk code'
         - org_name: some_name // Used to configure snyk organisation setting

--- a/bitrise.yml
+++ b/bitrise.yml
@@ -5,10 +5,10 @@ app:
   envs:
   # If you want to share this step into a StepLib
   - BITRISE_STEP_ID: bitrise-snyk-scan
-  - BITRISE_STEP_VERSION: "0.1.0"
+  - BITRISE_STEP_VERSION: "0.2.0"
   - BITRISE_STEP_GIT_CLONE_URL: https://github.com/Zegocover/bitrise-snyk-scan.git
   - MY_STEPLIB_REPO_FORK_GIT_URL: https://github.com/NataliaAn/bitrise-steplib.git
-       
+
 workflows:
   test:
     steps:

--- a/step.sh
+++ b/step.sh
@@ -23,7 +23,7 @@ function snykscannerios-run() {
     export PATH=$GEM_HOME/${ruby_version}/bin:$PATH
 
     gem install cocoapods --user-install    
-    pod install # for podfile
+    pod install --project-directory=${project_directory} # for podfile
 
     bundle install # for gemfile
 

--- a/step.yml
+++ b/step.yml
@@ -13,6 +13,11 @@ is_always_run: true
 is_skippable: true
 run_if: ""
 inputs:
+- project_directory: $BITRISE_SOURCE_DIR
+  opts:
+    title: "Project directory"
+    is_expand: false
+    is_required: true
 - os_list: ios
   opts:
     title: "Project's OS"


### PR DESCRIPTION
## Why
The step was assuming that the Podfile was always in the root path, but that isn't always the case.
In order to fix that I added a parameter to run the pod install with a different path.

## What
* Created parameter to set the project path with default as root. 
* Sending argument to pod install.