### PR TITLE
Correct gradle download link and `is_expand` for project_directory.

### DIFF
--- a/step.sh
+++ b/step.sh
@@ -34,7 +34,7 @@ function snykscannerios-run() {
 # for java and kotlin
 function snykscannerandroid-run() {
     echo "--- Install gradle"
-    curl https://downloads.gradle-dn.com/distributions/gradle-7.5.1-bin.zip --output gradle-7.5.1-bin.zip
+    curl https://services.gradle.org/distributions/gradle-7.5.1-bin.zip --output gradle-7.5.1-bin.zip
     unzip -qq -d /opt/gradle gradle-7.5.1-bin.zip
 
     export PATH=$PATH:/opt/gradle/gradle-7.5.1/bin

--- a/step.yml
+++ b/step.yml
@@ -16,7 +16,7 @@ inputs:
 - project_directory: $BITRISE_SOURCE_DIR
   opts:
     title: "Project directory"
-    is_expand: false
+    is_expand: true
     is_required: true
 - os_list: ios
   opts:


### PR DESCRIPTION
This fixes following issues: 

- Incorrect gradle link.
- When passing `project_directory` from `bitrise.yml`, the scan still checks in the `$BITRISE_SOURCE_DIR`.